### PR TITLE
fix model conversion for MC > 1.13

### DIFF
--- a/src/main/java/net/hypixel/resourcepack/impl/ModelConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/ModelConverter.java
@@ -75,22 +75,19 @@ public class ModelConverter extends Converter {
                         JsonObject textureObject = jsonObject.getAsJsonObject("textures");
                         for (Map.Entry<String, JsonElement> entry : textureObject.entrySet()) {
                             String value = entry.getValue().getAsString();
-                            if (version == 1.13) {
-                            if (value.startsWith("block/")) {
-                                textureObject.addProperty(entry.getKey(), "block/" + nameConverter.getBlockMapping().remap(value.substring("block/".length())));
-                            } else if (value.startsWith("item/")) {
-                                textureObject.addProperty(entry.getKey(), "item/" + nameConverter.getItemMapping().remap(value.substring("item/".length())));
-                            }
-                        }
                             if (version > 1.13) {
                                 if (value.startsWith("block/")) {
                                     textureObject.addProperty(entry.getKey(), "block/" + nameConverter.getNewBlockMapping().remap(value.substring("block/".length())));
                                 }
                             }
+                            if (version >= 1.13) {
+                                if (value.startsWith("block/")) {
+                                    textureObject.addProperty(entry.getKey(), "block/" + nameConverter.getBlockMapping().remap(value.substring("block/".length())));
+                                } else if (value.startsWith("item/")) {
+                                    textureObject.addProperty(entry.getKey(), "item/" + nameConverter.getItemMapping().remap(value.substring("item/".length())));
+                                }
+                            }
                         }
-
-
-
                     }
                     if (jsonObject.has("parent")) {
                         for(Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {


### PR DESCRIPTION
Currently the model conversion is only done when converting to MC 1.13.  If version > 1.13 it runs newBlockMapping() which converts entries using the mappings in Blocks1_14.json (of which there are only 2, both relating to stone_slabs).

This PR does the stone_slab conversion for MC 1.14+ first (otherwise the fact that there are no mappings for the majority of names in Blocks1_14.json, they will revert to the original name), followed by the full conversion for MC versions >= 1.13 (rather then == 1.13 only).