### PR TITLE
Forwards: Add Creative Tab Updater/Converter for going to 1.19.3+ 

### DIFF
--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/ForwardsPackConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/ForwardsPackConverter.java
@@ -91,8 +91,10 @@ public class ForwardsPackConverter extends PackConverter {
         this.registerConverter(new InventoryConverter(this));
 
         if (Util.getVersionProtocol(gson, from) < Util.getVersionProtocol(gson, "1.19.3")
-                && Util.getVersionProtocol(gson, to) >= Util.getVersionProtocol(gson, "1.19.3"))
+                && Util.getVersionProtocol(gson, to) >= Util.getVersionProtocol(gson, "1.19.3")) {
             this.registerConverter(new AtlasConverter(this));
+            this.registerConverter(new CreativeTabsConverter(this));
+        }
 
         if (Util.getVersionProtocol(gson, from) < Util.getVersionProtocol(gson, "1.19.4")
                 && Util.getVersionProtocol(gson, to) >= Util.getVersionProtocol(gson, "1.19.4"))

--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/CreativeTabsConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/CreativeTabsConverter.java
@@ -1,0 +1,85 @@
+package com.agentdid127.resourcepack.forwards.impl.textures;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.agentdid127.resourcepack.library.Converter;
+import com.agentdid127.resourcepack.library.PackConverter;
+import com.agentdid127.resourcepack.library.pack.Pack;
+import com.agentdid127.resourcepack.library.utilities.ImageConverter;
+
+public class CreativeTabsConverter extends Converter {
+    private static int old_tab_width = 28;
+    private static int new_tab_width = 26;
+    private static int old_half = old_tab_width/2;
+
+    public CreativeTabsConverter(PackConverter converter) {
+        super(converter);
+    }
+
+    @Override
+    public void convert(Pack pack) throws IOException {
+        Path guiPath = pack.getWorkingPath().resolve(
+                "assets" + File.separator + "minecraft" + File.separator + "textures" + File.separator + "gui");
+        if (!guiPath.toFile().exists())
+            return;
+
+        Path tabsImage = guiPath
+                .resolve("container" + File.separator + "creative_inventory" + File.separator + "tabs.png");
+        if (!tabsImage.toFile().exists())
+            return;
+
+        int originalWidth = 256;
+        int originalHeight = 256;
+        ImageConverter converter = new ImageConverter(originalWidth, originalHeight, tabsImage);
+        converter.newImage(originalWidth, originalHeight);
+
+        // Tabs
+        copy_tab(converter, 0, 0, 0, 2);
+        copy_tab(converter, 1, 1, 0, 2);
+        copy_tab(converter, 2, 2, 0, 2);
+        copy_tab(converter, 3, 3, 0, 2);
+        copy_tab(converter, 4, 4, 0, 2);
+        copy_tab(converter, 5, 4, 0, 2);
+        copy_tab(converter, 6, 5, 0, 2);
+        copy_tab(converter, 7, 6, 0, 2);
+        
+        // Scrollers
+        int scrollers_width = 24;
+        int scroller_height = 15;
+        int scroller_start_x = 232;
+        converter.subImage(
+            scroller_start_x,
+            0,
+            scroller_start_x + scrollers_width,
+            scroller_height,
+            scroller_start_x,
+            0);
+
+        converter.store();
+    }
+
+    private static void copy_tab(ImageConverter converter, int index, int original_index, int left_padding, int right_padding) {
+        int first_tab_start_x = original_index * old_tab_width;
+        int first_tab_start_end_x = (original_index * old_tab_width) + old_tab_width;
+
+        converter.subImage(
+            first_tab_start_x,
+            0,
+            first_tab_start_end_x - old_half,
+            160,
+            (index * new_tab_width) + left_padding,
+            0
+        );
+
+        converter.subImage(
+            first_tab_start_x + old_half,
+            0,
+            first_tab_start_end_x,
+            160,
+            ((index * new_tab_width) + (old_half - right_padding)),
+            0
+        );
+    }
+}


### PR DESCRIPTION
Adds a experimentalish converter to fix creative tabs for upgrading packs to versions past 1.19.3+ from before 1.19.3. 

The reason is its experimentalish is because, it works most of the time but some packs may have more detailed tabs causing it to look possibly weird afterwards or some just not working properly.