### PR TITLE
stop chests from remapping past 1.15

### DIFF
--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/ForwardsPackConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/ForwardsPackConverter.java
@@ -68,8 +68,8 @@ public class ForwardsPackConverter extends PackConverter {
             this.registerConverter(new LangConverter(this, from, to));
 
         this.registerConverter(new ParticleTextureConverter(this, protocolFrom, protocolTo));
-
-        this.registerConverter(new ChestConverter(this));
+        if (protocolFrom < Util.getVersionProtocol(gson, "1.15") && protocolTo >= Util.getVersionProtocol(gson, "1.15"))
+            this.registerConverter(new ChestConverter(this));
 
         if (protocolFrom <= Util.getVersionProtocol(gson, "1.13")
                 && protocolTo >= Util.getVersionProtocol(gson, "1.14.4"))


### PR DESCRIPTION
This PR should stop chests from appearing inside out in versions past MC 1.15.

This is a solution that fixed #179 .