### PR TITLE
Fix particle slicing/conversion

### DIFF
--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/ForwardsPackConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/ForwardsPackConverter.java
@@ -1,12 +1,12 @@
 package com.agentdid127.resourcepack.forwards;
 
+import com.agentdid127.resourcepack.forwards.impl.*;
 import com.agentdid127.resourcepack.forwards.impl.textures.*;
 import com.agentdid127.resourcepack.library.Converter;
 import com.agentdid127.resourcepack.library.PackConverter;
 import com.agentdid127.resourcepack.library.pack.Pack;
 import com.agentdid127.resourcepack.library.utilities.Logger;
 import com.agentdid127.resourcepack.library.utilities.Util;
-import com.agentdid127.resourcepack.forwards.impl.*;
 import com.google.gson.GsonBuilder;
 
 import java.io.IOException;

--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/ParticleTextureConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/ParticleTextureConverter.java
@@ -54,9 +54,9 @@ public class ParticleTextureConverter extends Converter {
                 converter.newImage(256, 256);
                 converter.subImage(0, 0, 128, 128, 0, 0);
                 converter.store();
-                slice.setWidth(256);
-                slice.setHeight(256);
             }
+            slice.setWidth(256);
+            slice.setHeight(256);
         }
 
         if (from <= Util.getVersionProtocol(gson, "1.13.2") &&

--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/ParticleTextureConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/ParticleTextureConverter.java
@@ -47,9 +47,9 @@ public class ParticleTextureConverter extends Converter {
         Slice slice = Slice.parse(particlesJson);
         if (from <= Util.getVersionProtocol(gson, "1.12.2") &&
                 to >= Util.getVersionProtocol(gson, "1.13")) {
-            Logger.log("Detected 'particles.png' from versions before 1.13, converting to newer size..");
             Path particlesPath = particlePath.resolve(slice.getPath());
             if (particlesPath.toFile().exists()) {
+                Logger.log("Detected 'particles.png' from versions before 1.13, converting to newer size..");
                 ImageConverter converter = new ImageConverter(slice.getWidth(), slice.getHeight(), particlesPath);
                 converter.newImage(256, 256);
                 converter.subImage(0, 0, 128, 128, 0, 0);

--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/ParticleTextureConverter.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/ParticleTextureConverter.java
@@ -45,16 +45,18 @@ public class ParticleTextureConverter extends Converter {
         assert particlesJson != null;
 
         Slice slice = Slice.parse(particlesJson);
-        if (from <= Util.getVersionProtocol(gson, "1.12.2") &&
-                to >= Util.getVersionProtocol(gson, "1.13")) {
-            Path particlesPath = particlePath.resolve(slice.getPath());
-            if (particlesPath.toFile().exists()) {
-                Logger.log("Detected 'particles.png' from versions before 1.13, converting to newer size..");
-                ImageConverter converter = new ImageConverter(slice.getWidth(), slice.getHeight(), particlesPath);
-                converter.newImage(256, 256);
-                converter.subImage(0, 0, 128, 128, 0, 0);
-                converter.store();
+        if (to >= Util.getVersionProtocol(gson, "1.13")) {
+            if (from <= Util.getVersionProtocol(gson, "1.12.2")) {
+                Path particlesPath = particlePath.resolve(slice.getPath());
+                if (particlesPath.toFile().exists()) {
+                    Logger.log("Detected 'particles.png' from versions before 1.13, converting to newer size..");
+                    ImageConverter converter = new ImageConverter(slice.getWidth(), slice.getHeight(), particlesPath);
+                    converter.newImage(256, 256);
+                    converter.subImage(0, 0, 128, 128, 0, 0);
+                    converter.store();
+                }
             }
+
             slice.setWidth(256);
             slice.setHeight(256);
         }

--- a/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/slicing/Slice.java
+++ b/conversions/Forwards/src/main/java/com/agentdid127/resourcepack/forwards/impl/textures/slicing/Slice.java
@@ -1,12 +1,12 @@
 package com.agentdid127.resourcepack.forwards.impl.textures.slicing;
 
-import java.io.File;
-import java.util.LinkedList;
-import java.util.List;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
 
 public class Slice {
     private String path;
@@ -31,6 +31,18 @@ public class Slice {
 
     public int getHeight() {
         return height;
+    }
+
+    public void setWidth(int width) {
+        if (this.width == width)
+            return;
+        this.width = width;
+    }
+
+    public void setHeight(int height) {
+        if (this.height == height)
+            return;
+        this.height = height;
     }
 
     public JsonObject getPredicate() {

--- a/conversions/Forwards/src/main/resources/forwards/particles.json
+++ b/conversions/Forwards/src/main/resources/forwards/particles.json
@@ -1,7 +1,7 @@
 {
     "path": "particles.png",
-    "width": 256,
-    "height": 256,
+    "width": 128,
+    "height": 128,
     "delete": true,
     "textures": [
         {

--- a/library/src/main/java/com/agentdid127/resourcepack/library/utilities/JsonUtil.java
+++ b/library/src/main/java/com/agentdid127/resourcepack/library/utilities/JsonUtil.java
@@ -1,20 +1,20 @@
 package com.agentdid127.resourcepack.library.utilities;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collections;
-
 import com.agentdid127.resourcepack.library.PackConverter;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 
 public class JsonUtil {
 	public static JsonArray add(JsonArray lhs, JsonArray rhs) {
@@ -63,7 +63,7 @@ public class JsonUtil {
 	}
 
 	public static void writeJson(Gson gson, Path out, JsonElement json) throws IOException {
-		Files.write(out, Collections.singleton(gson.toJson(json)), Charset.forName("UTF-8"));
+		Files.write(out, Collections.singleton(gson.toJson(json)), StandardCharsets.UTF_8);
 	}
 
 	public static boolean isJson(Gson gson, String Json) {


### PR DESCRIPTION
Fixes the scaling for particles.png compared to versions prior to 1.13 being 128x128, converting into 256x256 and adding a new if statement around the slicing so it only occurs for 1.14 and onward.