### PR TITLE
Add support for 1.21.8, bump version number

### DIFF
--- a/Applications/Console/pom.xml
+++ b/Applications/Console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>Applications</artifactId>
         <groupId>com.agentdid127.resourcepack</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Applications/Gui/pom.xml
+++ b/Applications/Gui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>Applications</artifactId>
         <groupId>com.agentdid127.resourcepack</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Applications/pom.xml
+++ b/Applications/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ResourcePackConverter</artifactId>
         <groupId>com.agentdid127</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
 
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -33,12 +33,12 @@
         <dependency>
             <groupId>com.agentdid127.resourcepack</groupId>
             <artifactId>Forwards</artifactId>
-            <version>2.2.5</version>
+            <version>2.2.6</version>
         </dependency>
         <dependency>
             <groupId>com.agentdid127.resourcepack</groupId>
             <artifactId>Backwards</artifactId>
-            <version>2.2.5</version>
+            <version>2.2.6</version>
         </dependency>
     </dependencies>
 

--- a/conversions/Backwards/pom.xml
+++ b/conversions/Backwards/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>conversions</artifactId>
         <groupId>com.agentdid127.resourcepack</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/conversions/Forwards/pom.xml
+++ b/conversions/Forwards/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>conversions</artifactId>
         <groupId>com.agentdid127.resourcepack</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/conversions/pom.xml
+++ b/conversions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ResourcePackConverter</artifactId>
         <groupId>com.agentdid127</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
 
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.agentdid127.resourcepack</groupId>
             <artifactId>Library</artifactId>
-            <version>2.2.5</version>
+            <version>2.2.6</version>
         </dependency>
     </dependencies>
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.agentdid127</groupId>
         <artifactId>ResourcePackConverter</artifactId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/library/src/main/resources/protocol.json
+++ b/library/src/main/resources/protocol.json
@@ -350,5 +350,9 @@
 	"1.21.7": {
 		"protocol_version": 772,
 		"pack_format": 64
-	}
+	},
+	"1.21.8": {
+		"protocol_version": 772,
+		"pack_format": 64
+        }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.agentdid127</groupId>
     <artifactId>ResourcePackConverter</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
     <packaging>pom</packaging>
     <name>ResourcePackConverter</name>
 


### PR DESCRIPTION
Adds full support for 1.21.8, as it is a hotfix update for Minecraft.