### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: write
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch


### PR DESCRIPTION
Potential fix for [https://github.com/agentdid127/ResourcePackConverter/security/code-scanning/3](https://github.com/agentdid127/ResourcePackConverter/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow creates releases and uploads release assets, it requires `contents: write`. The `permissions` block should be added at the top level of the workflow (after the `name:` field and before `jobs:`), so it applies to all jobs unless overridden. No other permissions appear to be required for this workflow. No changes to the steps or logic are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
