### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-2-0.yml
+++ b/.github/workflows/dev-2-0.yml
@@ -3,6 +3,9 @@
 
 name: Dev Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "2.0" ]


### PR DESCRIPTION
Potential fix for [https://github.com/agentdid127/ResourcePackConverter/security/code-scanning/2](https://github.com/agentdid127/ResourcePackConverter/security/code-scanning/2)

In general, fix this by explicitly defining a `permissions:` block that grants only the minimal rights needed, either at the workflow root (applies to all jobs) or within the specific job. This workflow only checks out code, builds with Maven, and uploads artifacts; these operations require at most read access to repository contents and do not need write access.

The single best fix here is to add a workflow-level `permissions:` block directly under the `name: Dev Build` line, setting `contents: read`. This will restrict the `GITHUB_TOKEN` to read-only repository contents for all jobs in this workflow. No changes to steps or additional imports are required. Concretely, in `.github/workflows/dev-2-0.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 5 and 6 (between `name: Dev Build` and `on:`). This preserves all existing behavior while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
