### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    permissions:
+      contents: write
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/agentdid127/ResourcePackConverter/security/code-scanning/1](https://github.com/agentdid127/ResourcePackConverter/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (or to the specific job) that grants only the minimum rights needed for the steps that use `GITHUB_TOKEN`. This avoids relying on potentially broad repository defaults.

For this workflow, only the `build` job exists and it uses `actions/create-release@v1` and `actions/upload-release-asset@v1`, both of which require write access to repository contents to create a GitHub Release and upload assets. So the minimal useful permissions for this job are:

```yaml
permissions:
  contents: write
```

The safest, least intrusive change is to add a job-level `permissions` block under `build:` (on or just after line 15–16) so it applies only to this job without affecting any other workflows. Concretely, in `.github/workflows/prerelease.yml`, under:

```yaml
14:   build:
15:     # The type of runner that the job will run on
16:     runs-on: ubuntu-latest
```

insert:

```yaml
15:     permissions:
16:       contents: write
17:     # The type of runner that the job will run on
18:     runs-on: ubuntu-latest
```

(adjusting line numbers accordingly). No imports or external dependencies are needed; this is just standard GitHub Actions YAML configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
